### PR TITLE
Add PositionState property

### DIFF
--- a/src/event/LastDirection.ts
+++ b/src/event/LastDirection.ts
@@ -1,0 +1,4 @@
+export enum LastDirection {
+  "Open" = "Open",
+  "Close" = "Close",
+}

--- a/src/event/property.ts
+++ b/src/event/property.ts
@@ -1,4 +1,5 @@
 import { FanSpeed } from './FanSpeed';
+import { LastDirection } from './LastDirection';
 
 export interface Property {
   Brightness?: string;
@@ -7,4 +8,5 @@ export interface Property {
   BasicState?: string;
   FanSpeed?: FanSpeed;
   Moving?: string;
+  LastDirection?: LastDirection;
 }


### PR DESCRIPTION
Adds the missing property LastDirection.
Can be used to map to Homebridge LastPositionState
https://developers.homebridge.io/#/characteristic/PositionState
